### PR TITLE
Combat log improvements

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -16,7 +16,7 @@ class Controller:
     
     def send_logs(self):
         """Send logs to the GUI."""
-        self.app.game.screen.combat_log.flush_log_messages(self.event_manager)
+        self.app.game.screen.combat_log.flush_queue(self.event_manager)
     
     def display_hand(self, hand):
         """Display the player's hand in the GUI."""

--- a/core/effects.py
+++ b/core/effects.py
@@ -178,10 +178,17 @@ class ChangeResourceEffect(Effect):
         Change the resource's current value by the amount indicated.
         """
         subject = self.get_target_combatant(source, opponent)
+        old_value = subject.resources[self.resource_enum.name].current
         subject.change_resource(self.resource_enum.name, level)
-        action_string = "restored" if level > 0 else "drained"
+        new_value = subject.resources[self.resource_enum.name].current
+        if level > 0:
+            action_string = "restored"
+            actual_change = new_value - old_value
+        else:
+            action_string = "drained"
+            actual_change = old_value - new_value
         registries.statuses.event_manager.logger.log(
-            f"{abs(level)} {self.resource_enum.value} {action_string}!"
+            f"{actual_change} {self.resource_enum.value} {action_string}!"
         )
 
 

--- a/gameplay/combat_manager.py
+++ b/gameplay/combat_manager.py
@@ -14,6 +14,7 @@ class CombatManager:
         Initialize a new CombatManager.
         """
         self.event_manager = event_manager
+        self.turn_number = 0
 
     def is_combat_over(self, player, enemy) -> bool:
         """
@@ -25,6 +26,7 @@ class CombatManager:
         """
         Set up for combat.
         """
+        self.turn_number = 0
         player.card_manager.shuffle()
         enemy.card_manager.shuffle()
         self.event_manager.dispatch('start_combat', enemy)
@@ -44,7 +46,9 @@ class CombatManager:
         #     registries.statuses, combatant.card_manager
         #     )
         combatant.replenish_resources_for_turn()
-        if not combatant.is_enemy:
+        if not combatant.is_enemy:  # Player turn
+            if self.turn_number == 0:
+                self.event_manager.logger.log(f"Enemy {opponent.name} appears!")
             self.event_manager.dispatch('start_action_phase', combatant.card_manager.hand)
 
     def end_of_turn(self, combatant, status_registry):
@@ -153,4 +157,5 @@ class CombatManager:
                         return
                     break
         self.end_of_turn(enemy, registries.statuses)
+        self.turn_number += 1
         self.event_manager.dispatch('end_enemy_turn')

--- a/gameplay/status_manager.py
+++ b/gameplay/status_manager.py
@@ -24,7 +24,7 @@ class StatusManager:
         if status_id not in self.statuses:
             return
         leveled_status = self.statuses[status_id]
-        leveled_status.reference.expire(subject, self.event_manager.logger)
+        # leveled_status.reference.expire(subject, self.event_manager.logger)
         del self.statuses[status_id]
 
     def get_leveled_status(self, status_id) -> LeveledMechanic:

--- a/gui/card.py
+++ b/gui/card.py
@@ -69,7 +69,8 @@ class Card(Widget):
 
     def on_touch_down(self, touch) -> bool:
         """When clicked, pick up the card. Return true to stop event propagation."""
-        if not self.is_draggable or not self.collide_point(touch.x, touch.y):
+        if self.screen.combat_log.timer_is_running or self.screen.combat_log.flush_in_progress \
+            or not self.is_draggable or not self.collide_point(touch.x, touch.y):
             return False
         self.click_location = (touch.x, touch.y)
         self.starting_position = (self.center_x, self.center_y)

--- a/gui/combat_log.py
+++ b/gui/combat_log.py
@@ -28,7 +28,6 @@ class CombatLog(Widget):
         self.timer_is_running = False
         self.log_toggled_on = False
         self.flush_in_progress = False
-        self.remove_widget(self.combat_log_scrollview)  # temporary fix to hide the log until it's needed
 
     def get_log_messages(self, event_manager):
         """Fetches new log messages from the event manager."""

--- a/gui/combat_log.py
+++ b/gui/combat_log.py
@@ -1,0 +1,50 @@
+"""
+Module for the combat log widget in the card game GUI.
+"""
+
+from kivy.uix.widget import Widget
+from kivy.properties import ObjectProperty
+from kivy.clock import Clock
+
+class CombatLog(Widget):
+    """Widget representing the combat log."""
+    combat_log_label = ObjectProperty(None)
+
+    def __init__(self, **kwargs):
+        """Initialize a new CombatLog."""
+        super().__init__(**kwargs)
+        self.history = []
+        self.pending = []
+        self.log_shown = False
+
+    def flush_log_messages(self, event_manager):
+        """Writes all pending log messages to the log display."""
+        self.pending += event_manager.logger.get_combat_logs()
+        if self.pending:
+            Clock.schedule_interval(self.log_message, 0.33)
+    
+    def log_message(self, dt):
+        if self.pending:
+            message = self.pending.pop(0)
+            self.history.append(message)
+            if self.combat_log_label.text:
+                self.combat_log_label.text += "\n"
+            self.combat_log_label.text += message
+        if not self.pending:
+            Clock.unschedule(self.log_message)
+            if not self.log_shown:
+                Clock.schedule_once(self.hide_message, 2)  
+    
+    def hide_message(self, dt):
+        """Hides the current message after a delay."""
+        self.combat_log_label.text = ""
+
+    def show_history(self):
+        """Displays the combat log history."""
+        self.combat_log_label.text = "\n".join(self.history)
+        self.log_shown = True
+    
+    def hide_history(self):
+        """Hides the combat log history."""
+        self.combat_log_label.text = ""
+        self.log_shown = False

--- a/gui/combat_log.py
+++ b/gui/combat_log.py
@@ -9,42 +9,108 @@ from kivy.clock import Clock
 class CombatLog(Widget):
     """Widget representing the combat log."""
     combat_log_label = ObjectProperty(None)
+    combat_log_scrollview = ObjectProperty(None)
 
     def __init__(self, **kwargs):
         """Initialize a new CombatLog."""
         super().__init__(**kwargs)
-        self.history = []
-        self.pending = []
-        self.log_shown = False
+        self.queue = []
+        # queue has the following structure:
+        # [
+        #     {
+        #         "message": "Message text to display",
+        #         "delay": 0.3,  # seconds to wait before showing the next message
+        #         "sound": "sword_hit",
+        #         "animation": "player_hit"
+        #     },
+        #     ...
+        # ]
+        self.timer_is_running = False
+        self.log_toggled_on = False
+        self.flush_in_progress = False
+        self.message = ""
+        self.remove_widget(self.combat_log_scrollview)  # temporary fix to hide the log until it's needed
 
-    def flush_log_messages(self, event_manager):
-        """Writes all pending log messages to the log display."""
-        self.pending += event_manager.logger.get_combat_logs()
-        if self.pending:
-            Clock.schedule_interval(self.log_message, 0.33)
+    def get_log_messages(self, event_manager):
+        """Fetches new log messages from the event manager."""
+        new_messages = event_manager.logger.get_combat_logs()
+        if new_messages:
+            self.queue.extend(new_messages)
     
-    def log_message(self, dt):
-        if self.pending:
-            message = self.pending.pop(0)
-            self.history.append(message)
+    def flush_queue(self, event_manager):
+        """Flushes the message queue to the log display."""
+        self.get_log_messages(event_manager)
+        if self.queue and not self.flush_in_progress:
+            self.show_log()
+            self.flush_in_progress = True
+            delay = 0.0
+            while self.queue:
+                # message_info = self.queue.pop(0)
+                # self.message = message_info.get("message", "")
+                # sound = message_info.get("sound", None)
+                # animation = message_info.get("animation", None)
+                self.message = self.queue.pop(0)
+                Clock.schedule_once(self.display, delay)
+                delay = 0.3 # message_info.get("delay", 0.3)
+            self.flush_in_progress = False
+            self.timer_is_running = True
+            Clock.schedule_once(self.auto_hide_log, delay + 2)
+    
+    def display(self, dt):
+        """Displays the current message."""
+        if self.message:
             if self.combat_log_label.text:
                 self.combat_log_label.text += "\n"
-            self.combat_log_label.text += message
-        if not self.pending:
-            Clock.unschedule(self.log_message)
-            if not self.log_shown:
-                Clock.schedule_once(self.hide_message, 2)  
+            self.combat_log_label.text += self.message
+            self.message = ""
+            self.combat_log_scrollview.scroll_y = 0
     
-    def hide_message(self, dt):
-        """Hides the current message after a delay."""
-        self.combat_log_label.text = ""
+    def show_log(self):
+        """Shows the combat log if it's not already visible."""
+        if not self.combat_log_scrollview.parent:
+            self.add_widget(self.combat_log_scrollview)
+            self.log_shown = True
 
-    def show_history(self):
-        """Displays the combat log history."""
-        self.combat_log_label.text = "\n".join(self.history)
-        self.log_shown = True
+    def hide_log(self):
+        """Hides the combat log."""
+        if self.combat_log_scrollview.parent:
+            self.remove_widget(self.combat_log_scrollview)
+            self.log_shown = False
     
-    def hide_history(self):
-        """Hides the combat log history."""
-        self.combat_log_label.text = ""
-        self.log_shown = False
+    def auto_hide_log(self, dt):
+        """Automatically hides the combat log after a delay."""
+        if not self.log_toggled_on:
+            self.hide_log()
+        self.timer_is_running = False
+
+    # def flush_log_messages(self, event_manager):
+    #     """Writes all pending log messages to the log display."""
+    #     self.pending += event_manager.logger.get_combat_logs()
+    #     if self.pending:
+    #         Clock.schedule_interval(self.log_message, 0.33)
+    
+    # def log_message(self, dt):
+    #     if self.pending:
+    #         message = self.pending.pop(0)
+    #         self.history.append(message)
+    #         if self.combat_log_label.text:
+    #             self.combat_log_label.text += "\n"
+    #         self.combat_log_label.text += message
+    #     if not self.pending:
+    #         Clock.unschedule(self.log_message)
+    #         if not self.log_shown:
+    #             Clock.schedule_once(self.hide_message, 2)  
+    
+    # def hide_message(self, dt):
+    #     """Hides the current message after a delay."""
+    #     self.combat_log_label.text = ""
+
+    # def show_history(self):
+    #     """Displays the combat log history."""
+    #     self.combat_log_label.text = "\n".join(self.history)
+    #     self.log_shown = True
+    
+    # def hide_history(self):
+    #     """Hides the combat log history."""
+    #     self.combat_log_label.text = ""
+    #     self.log_shown = False

--- a/gui/combat_log.py
+++ b/gui/combat_log.py
@@ -28,7 +28,6 @@ class CombatLog(Widget):
         self.timer_is_running = False
         self.log_toggled_on = False
         self.flush_in_progress = False
-        self.message = ""
         self.remove_widget(self.combat_log_scrollview)  # temporary fix to hide the log until it's needed
 
     def get_log_messages(self, event_manager):
@@ -46,24 +45,25 @@ class CombatLog(Widget):
             delay = 0.0
             while self.queue:
                 # message_info = self.queue.pop(0)
-                # self.message = message_info.get("message", "")
+                # message = message_info.get("message", "")
                 # sound = message_info.get("sound", None)
                 # animation = message_info.get("animation", None)
-                self.message = self.queue.pop(0)
-                Clock.schedule_once(self.display, delay)
+                message = self.queue.pop(0)
+                Clock.schedule_once(self.create_log_updater(message), delay)
                 delay = 0.3 # message_info.get("delay", 0.3)
             self.flush_in_progress = False
             self.timer_is_running = True
             Clock.schedule_once(self.auto_hide_log, delay + 2)
     
-    def display(self, dt):
-        """Displays the current message."""
-        if self.message:
-            if self.combat_log_label.text:
-                self.combat_log_label.text += "\n"
-            self.combat_log_label.text += self.message
-            self.message = ""
-            self.combat_log_scrollview.scroll_y = 0
+    def create_log_updater(self, message):
+        """Create a function that adds a message to the combat log."""
+        def update_log(dt):
+            if message:
+                if self.combat_log_label.text:
+                    self.combat_log_label.text += "\n"
+                self.combat_log_label.text += message
+                self.combat_log_scrollview.scroll_y = 0
+        return update_log
     
     def show_log(self):
         """Shows the combat log if it's not already visible."""

--- a/gui/combat_log.py
+++ b/gui/combat_log.py
@@ -82,35 +82,3 @@ class CombatLog(Widget):
         if not self.log_toggled_on:
             self.hide_log()
         self.timer_is_running = False
-
-    # def flush_log_messages(self, event_manager):
-    #     """Writes all pending log messages to the log display."""
-    #     self.pending += event_manager.logger.get_combat_logs()
-    #     if self.pending:
-    #         Clock.schedule_interval(self.log_message, 0.33)
-    
-    # def log_message(self, dt):
-    #     if self.pending:
-    #         message = self.pending.pop(0)
-    #         self.history.append(message)
-    #         if self.combat_log_label.text:
-    #             self.combat_log_label.text += "\n"
-    #         self.combat_log_label.text += message
-    #     if not self.pending:
-    #         Clock.unschedule(self.log_message)
-    #         if not self.log_shown:
-    #             Clock.schedule_once(self.hide_message, 2)  
-    
-    # def hide_message(self, dt):
-    #     """Hides the current message after a delay."""
-    #     self.combat_log_label.text = ""
-
-    # def show_history(self):
-    #     """Displays the combat log history."""
-    #     self.combat_log_label.text = "\n".join(self.history)
-    #     self.log_shown = True
-    
-    # def hide_history(self):
-    #     """Hides the combat log history."""
-    #     self.combat_log_label.text = ""
-    #     self.log_shown = False

--- a/gui/combat_screen.kv
+++ b/gui/combat_screen.kv
@@ -574,24 +574,32 @@
         CombatLog:
             id: combat_log
             combat_log_label: combat_log_label
+            combat_log_scrollview: combat_log_scrollview
             pos: 316, 324
-            size: 868, combat_log_label.texture_size[1] + 4
+            size: 868, 100
             size_hint: None, None
-            canvas.before:
-                Color:
-                    rgba: (0, 0, 0, 1)
-                Rectangle:
-                    pos: self.pos
-                    size: self.size
 
-            Label:
-                id: combat_log_label
-                text: ''
-                font_size: 16
-                color: (1, 1, 1, 1)
-                size: self.parent.width, self.texture_size[1]
-                size_hint: None, None
-                pos: self.parent.pos
+            ScrollView:
+                id: combat_log_scrollview
+                do_scroll_x: False
+                do_scroll_y: True
+                pos: 316, 324
+                size: 868, 100
+                canvas.before:
+                    Color:
+                        rgba: (0, 0, 0, 1)
+                    Rectangle:
+                        pos: self.pos
+                        size: self.size
+                Label:
+                    id: combat_log_label
+                    text: ''
+                    font_size: 16
+                    color: (1, 1, 1, 1)
+                    size: self.parent.width, self.texture_size[1]
+                    size_hint: None, None
+                    pos: self.parent.pos
+                    padding: 10, 10
 
         Hand:
             id: hand

--- a/gui/combat_screen.py
+++ b/gui/combat_screen.py
@@ -9,6 +9,7 @@ import gui.gui_constants as constants
 from gui.asset_cache import AssetCache
 from gui.card import Card
 from gui.tooltips import Tooltip
+from gui.combat_log import CombatLog
 
 class Hand(FloatLayout):
     """Widget representing the player's hand of cards."""
@@ -59,50 +60,6 @@ class Hand(FloatLayout):
         for card in self.children[:]:
             self.remove_widget(card)
         self.position_cards()
-
-
-class CombatLog(Widget):
-    """Widget representing the combat log."""
-    combat_log_label = ObjectProperty(None)
-
-    def __init__(self, **kwargs):
-        """Initialize a new CombatLog."""
-        super().__init__(**kwargs)
-        self.history = []
-        self.pending = []
-        self.log_shown = False
-
-    def flush_log_messages(self, event_manager):
-        """Writes all pending log messages to the log display."""
-        self.pending += event_manager.logger.get_combat_logs()
-        if self.pending:
-            Clock.schedule_interval(self.log_message, 0.33)
-    
-    def log_message(self, dt):
-        if self.pending:
-            message = self.pending.pop(0)
-            self.history.append(message)
-            if self.combat_log_label.text:
-                self.combat_log_label.text += "\n"
-            self.combat_log_label.text += message
-        if not self.pending:
-            Clock.unschedule(self.log_message)
-            if not self.log_shown:
-                Clock.schedule_once(self.hide_message, 2)  
-    
-    def hide_message(self, dt):
-        """Hides the current message after a delay."""
-        self.combat_log_label.text = ""
-
-    def show_history(self):
-        """Displays the combat log history."""
-        self.combat_log_label.text = "\n".join(self.history)
-        self.log_shown = True
-    
-    def hide_history(self):
-        """Hides the combat log history."""
-        self.combat_log_label.text = ""
-        self.log_shown = False
 
 
 class ScreenDarken(Widget):

--- a/gui/combat_screen.py
+++ b/gui/combat_screen.py
@@ -289,19 +289,20 @@ class CombatScreen(Widget):
     
     def toggle_log(self):
         """Toggles the log display."""
-        if self.combat_log.log_shown:
-            self.combat_log.hide_history()
-            self.combat_log.log_shown = False
+        if self.combat_log.log_toggled_on:
+            self.combat_log.log_toggled_on = False
             self.log_texture = AssetCache.get_texture('gui/assets/logbookclosed.png')
+            if not self.combat_log.timer_is_running:
+                self.combat_log.hide_log()
         else:
-            self.combat_log.show_history()
-            self.combat_log.log_shown = True
+            self.combat_log.log_toggled_on = True
             self.log_texture = AssetCache.get_texture('gui/assets/logbookopen.png')
-    
+            self.combat_log.show_log()
+
     def show_combat_results(self, player_wins, rewards):
         """Shows the combat results."""
         Clock.unschedule(self.loop_textures)
-        self.combat_log.flush_log_messages(self.event_manager)
+        self.combat_log.flush_queue(self.event_manager)
         self.animation_layer.add_widget(ScreenDarken())
         combat_results = CombatResults(self.event_manager)
         self.add_widget(combat_results)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -9,6 +9,7 @@ class Logger:
         self.write_to_file = write_to_file
         self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     
+    # TODO: log messages with more structured data (e.g. type, source, etc.) and use that to enhance the combat log display (e.g. different colors for different types of messages)
     def log(self, message, is_debug=False):
         """
         Add a new log entry.


### PR DESCRIPTION
Closes #183 - Put the Label into a Scrollview

Closes #182 - Make sure statuses don't log expiration when removed as part of combat cleanup

Closes #132 - Don't automatically hide the log if it has been toggled on manually

Closes #157 - Fix timing issues

Closes #181 - Make each log message a little production with framework for future sounds and visuals

Closes #185 - Track turn numbers but don't log them directly at this time

The first step will be to separate CombatLog to its own module.